### PR TITLE
Update SqlServerMemory.cs - Fixes issue #109 

### DIFF
--- a/src/KernelMemory.MemoryStorage.SqlServer/SqlServerMemory.cs
+++ b/src/KernelMemory.MemoryStorage.SqlServer/SqlServerMemory.cs
@@ -8,6 +8,7 @@ using Microsoft.KernelMemory.Diagnostics;
 using Microsoft.KernelMemory.MemoryStorage;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -639,7 +640,9 @@ public class SqlServerMemory : IMemoryDb
         {
             command.CommandText = "SELECT SERVERPROPERTY('ProductMajorVersion')";
 
-            return (int)command.ExecuteScalar();
+            var result = command.ExecuteScalar();
+
+            return Convert.ToInt32(result, CultureInfo.InvariantCulture);
         }
     }
 }

--- a/src/KernelMemory.MemoryStorage.SqlServer/SqlServerMemory.cs
+++ b/src/KernelMemory.MemoryStorage.SqlServer/SqlServerMemory.cs
@@ -97,8 +97,7 @@ public class SqlServerMemory : IMemoryDb
                     
                     IF OBJECT_ID(N'[{this._config.Schema}.IXC_{$"{this._config.EmbeddingsTableName}_{index}"}]', N'U') IS NULL
                     CREATE CLUSTERED COLUMNSTORE INDEX [IXC_{$"{this._config.EmbeddingsTableName}_{index}"}]
-                    ON {this.GetFullTableName($"{this._config.EmbeddingsTableName}_{index}")}
-                    ORDER ([memory_id]);
+                    ON {this.GetFullTableName($"{this._config.EmbeddingsTableName}_{index}")};
                     
                     IF OBJECT_ID(N'{this.GetFullTableName($"{this._config.TagsTableName}_{index}")}', N'U') IS NULL
                     CREATE TABLE {this.GetFullTableName($"{this._config.TagsTableName}_{index}")}


### PR DESCRIPTION
Fixes the exception, when creating an index for the first time: 
`Incorrect syntax near the keyword 'ORDER'.` from #109 

[ChatGPT response to the issue](https://chat.openai.com/share/e/22ee8740-1bc0-49ed-ae42-9600d1c2464d)

Tested it after this change, and it works.

## Description

What's new?

- Removed ORDER syntax in the CreateIndex method

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other